### PR TITLE
Enable/disable snippets syntax resolving.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,11 +89,19 @@ export function activate(context: vscode.ExtensionContext) {
 		if (!snippet) {
 			return;
 		}
-		vscode.commands.executeCommand("editor.action.insertSnippet",
-			{
-				snippet: snippet.value
-			}
-		);
+		// note: enable syntax resolving by default if property is not yet defined in JSON
+		if (snippet.resolveSyntax === undefined) {
+			snippet.resolveSyntax = true;
+		}
+		if (snippet.resolveSyntax) {
+			vscode.commands.executeCommand("editor.action.insertSnippet", { snippet: snippet.value }
+			);
+		} else {
+			editor.edit(edit => {
+				edit.insert(editor.selection.start, snippet.value);
+			});
+		}
+
 		vscode.window.showTextDocument(editor.document);
 	}));
 
@@ -204,6 +212,10 @@ export function activate(context: vscode.ExtensionContext) {
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand(Commands.editSnippet, (snippet: Snippet) => {
+		// note: enable syntax resolving by default if property is not yet defined in JSON
+		if (snippet.resolveSyntax === undefined) {
+			snippet.resolveSyntax = true;
+		}
 		// Create and show a new webview for editing snippet
 		new EditSnippet(context, snippet, snippetsProvider);
 	}));

--- a/src/interface/snippet.ts
+++ b/src/interface/snippet.ts
@@ -8,6 +8,7 @@ export class Snippet {
   children: Array<Snippet>;
   value?: string;
   lastId?: number;
+  resolveSyntax?: boolean;
 
   constructor(
     id: number,

--- a/src/views/editSnippet.ts
+++ b/src/views/editSnippet.ts
@@ -17,13 +17,17 @@ export class EditSnippet extends EditView {
     handleReceivedMessage(message: any): any {
         switch (message.command) {
             case 'edit-snippet':
-                const { label, value } = message.data;
+                const { label, value, resolveSyntax } = message.data;
                 // call provider only if there is data change
-                if (label) {
+                if (label !== undefined) {
                     this._snippet.label = label;
                 }
-                if (value) {
+                if (value !== undefined) {
                     this._snippet.value = value;
+                }
+                // test against undefined so we don't mess with variable's state if user introduces an explicit value 'false'
+                if (resolveSyntax !== undefined) {
+                    this._snippet.resolveSyntax = resolveSyntax;
                 }
                 this._snippetsProvider.editSnippet(this._snippet);
                 this._panel.dispose();

--- a/views/editSnippet.html
+++ b/views/editSnippet.html
@@ -21,6 +21,9 @@
                 Snippet syntax was detected: see
                 <a href="{{docsUrl}}" target="_blank">docs</a>
                 for more information.
+                
+                <input type="checkbox" id="snippet-resolveSyntax" name="_snippets_resolve_syntax" value="{{snippet.resolveSyntax}}">
+                <label for="snippet-resolveSyntax"> Resolve Snippet Syntax</label>
             </div>
         </div>
         <div><textarea name="snippet-value" rows="10" required>{{snippet.value}}</textarea></div>

--- a/views/js/editSnippet.js
+++ b/views/js/editSnippet.js
@@ -1,16 +1,21 @@
 (function() {
     const vscode = acquireVsCodeApi();
 
+    const resolveSyntaxCB = document.lastChild.querySelector('input[name="_snippets_resolve_syntax"]');
+    resolveSyntaxCB.checked = resolveSyntaxCB.value === "true" ? "checked" : "" ;
+
     document.querySelector('form').addEventListener('submit', (e) => {
         e.preventDefault();
         const form = document.querySelector('form[name="edit-snippet-form"]');
         const snippetLabel = form.elements['snippet-label'].value;
         const snippetValue = form.elements['snippet-value'].value;
+        const resolveSyntax = form.elements['snippet-resolveSyntax'].checked;
 
         vscode.postMessage({
             data: {
                 label: snippetLabel,
-                value: snippetValue
+                value: snippetValue,
+                resolveSyntax: resolveSyntax
             },
             command: 'edit-snippet'
         });


### PR DESCRIPTION
Fixes #8 

Snippets syntax resolving is now optional. **It is enabled** by default.
All your previous snippets already created will have the default behavior which is resolving syntax once placeholders are detected.

A checkbox has been added to enable/disable this feature in the edit tab:
![image](https://user-images.githubusercontent.com/12661966/114288950-bd1e7480-9a6b-11eb-928e-61febf4d75af.png)

- If the syntax resolving is enabled (checkbox checked), opening that snippet in the editor will resolve all placeholders and will process all variables with dollar sign ($) for instance:
![image](https://user-images.githubusercontent.com/12661966/114288979-15ee0d00-9a6c-11eb-94ff-1af221d756e7.png)

- If syntax resolving is disabled (checkbox unchecked), opening same snippet in the editor will show it as it originally written, keeping all dollar signs for instance:
![image](https://user-images.githubusercontent.com/12661966/114288995-3e760700-9a6c-11eb-962a-360659a8d894.png)

This is useful when trying to save a snippet of code and keep it as it is, without the need of additional processing from VSCode.