### PR TITLE
Sync snippets across open workspaces.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const snippetService = new SnippetService(dataAccess);
 	const snippetsProvider = new SnippetsProvider(snippetService, context.extensionPath);
 
+	// watch changes on snippets file, this will prevent de-sync between multiple open workspaces
+	fs.watchFile(snippetsPath, () => {
+		snippetsProvider.refresh();
+	});
+
 	vscode.workspace.onDidChangeConfiguration(event => {
 		let affected = event.affectsConfiguration(`snippets.${snippetsPathConfigKey}`);
 		if (affected && !explicitUpdate) {

--- a/src/provider/snippetsProvider.ts
+++ b/src/provider/snippetsProvider.ts
@@ -23,9 +23,16 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet> {
     private _onDidChangeTreeData: vscode.EventEmitter<Snippet | undefined | null | void> = new vscode.EventEmitter<Snippet | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<Snippet | undefined | null | void> = this._onDidChangeTreeData.event;
 
+    // only read from data file
     refresh(): void {
-        this._snippetService.saveSnippets();
+        this._snippetService.refresh();
         this._onDidChangeTreeData.fire();
+    }
+
+    // save state of snippets, then refresh
+    sync(): void {
+        this._snippetService.saveSnippets();
+        this.refresh();
     }
 
     addSnippet(name: string, snippet: string, parentId: number) {
@@ -41,7 +48,7 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet> {
             }
         );
 
-        this.refresh();
+        this.sync();
     }
 
     addSnippetFolder(name: string, parentId: number) {
@@ -57,37 +64,37 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet> {
             }
         );
 
-        this.refresh();
+        this.sync();
     }
 
     editSnippet(snippet: Snippet) {
         this._snippetService.updateSnippet(snippet);
 
-        this.refresh();
+        this.sync();
     }
 
     editSnippetFolder(snippet: Snippet) {
         this._snippetService.updateSnippet(snippet);
 
-        this.refresh();
+        this.sync();
     }
 
     removeSnippet(snippet: Snippet) {
         this._snippetService.removeSnippet(snippet);
 
-        this.refresh();
+        this.sync();
     }
 
     moveSnippetUp(snippet: Snippet) {
         this._snippetService.moveSnippet(snippet, -1);
 
-        this.refresh();
+        this.sync();
     }
 
     moveSnippetDown(snippet: Snippet) {
         this._snippetService.moveSnippet(snippet, 1);
 
-        this.refresh();
+        this.sync();
     }
 
     private snippetToTreeItem(snippet: Snippet): vscode.TreeItem {

--- a/src/service/snippetService.ts
+++ b/src/service/snippetService.ts
@@ -5,7 +5,7 @@ export class SnippetService {
     private _rootSnippet: Snippet;
 
     constructor(private _dataAccess: DataAccess) {
-        this._rootSnippet = _dataAccess.readFile();
+        this._rootSnippet = this.loadSnippets();
     }
 
     // static utility methods
@@ -66,6 +66,14 @@ export class SnippetService {
     }
     
     // public service methods
+
+    refresh(): void {
+        this._rootSnippet = this.loadSnippets();
+    }
+
+    loadSnippets(): Snippet {
+        return this._dataAccess.readFile();
+    }
     
     saveSnippets(): void {
         this._dataAccess.writeToFile(this._rootSnippet);
@@ -76,6 +84,8 @@ export class SnippetService {
     }
 
     getAllSnippets(): Snippet[] {
+        // sync snippets
+        this._rootSnippet = this.loadSnippets();
         let snippets: Snippet[] = [];
         SnippetService.flatten(this._rootSnippet.children, snippets);
         return snippets;


### PR DESCRIPTION
Fixes #11 

Sync snippets across open editors by watching changes on the data file, once a change is detected, trigger refresh explicitly.