### PR TITLE
Fix default path availability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "snippets",
 	"displayName": "Snippets",
 	"description": "Manage your code snippets without quitting your editor.",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"preview": true,
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"publisher": "tahabasri",

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -23,8 +23,8 @@ export const enum Labels {
 	snippetFolderNameErrorMsg = "Snippet folder must have a non-empty name.",
 
 	snippetsDefaultPath = "Snippets will be saved to default location [{0}].",
-	snippetsInvalidPath = "Snippets path is not a valid JSON file, will revert back to default location [{0}].",
+	snippetsInvalidPath = "Snippets path [{0}] is not a valid JSON file, will revert back to default location [{1}].",
 	snippetsChangedPath = "Snippets location changed to [{0}]",
-	snippetsInvalidNewPath = "Snippets path is not a valid JSON file, will revert back to old location [{0}].",
+	snippetsInvalidNewPath = "Snippets path [{0}] is not a valid JSON file, will revert back to old location [{1}].",
 	snippetsNoNewPath = "Snippets will be saved to old location [{0}].",
 }


### PR DESCRIPTION
Fixes #18

Default path should be always available even when not used (other value in settings). This should fix a fresh installation of the extension.