### PR TITLE
Added save to workspace for workspace related snippets and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Easily backup your snippets by changing their default location. This can be usef
 <img src="https://raw.githubusercontent.com/tahabasri/snippets/main/images/features/10-backup-snippets.png" 
 alt="Backup Snippets">
 
+
+Or save them inside your workspace folder by adding this to your settings.
+```
+"snippets.useWorkspaceFolder": true,
+"snippets.snippetsLocation": ".vscode/snippets.json",
+```
+
 **Enjoy!**
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ This extension takes snippets to another level bringing new features which will 
   - [Open Snippet](#open-snippet)
   - [Edit Snippet](#edit-snippet)
   - [Backup your Snippets outside VSCode](#backup-your-snippets-outside-vscode)
-- [Extension Settings](#extension-settings)
+  - [Backup your Snippets inside your workspace](#backup-your-snippets-inside-your-workspace)
 - [Installation](#installation)
 - [Known Issues](#known-issues)
 - [Release Notes](#release-notes)
+- [1.2.0](#120)
+- [1.1.1](#111)
+- [1.1.0](#110)
+- [1.0.0](#100)
 - [Feedback](#feedback)
-- [Credits](#credits)
+  - [Credits](#credits)
 
 ## Features
 
@@ -82,12 +86,14 @@ Easily backup your snippets by changing their default location. This can be usef
 <img src="https://raw.githubusercontent.com/tahabasri/snippets/main/images/features/10-backup-snippets.png" 
 alt="Backup Snippets">
 
+### Backup your Snippets inside your workspace
 
-Or save them inside your workspace folder by adding this to your settings.
+To save snippets inside your workspace folder, add this to your workspace settings.
 ```
 "snippets.useWorkspaceFolder": true,
-"snippets.snippetsLocation": ".vscode/snippets.json",
 ```
+This will use the snippets in that specific workspace. Your global snippets will not be used.
+To only use the snippets of the workspace it's recommended not to enable this setting in your user setting.
 
 **Enjoy!**
 
@@ -105,6 +111,9 @@ alt="Permissions issue">
 
 ## Release Notes
 
+## 1.2.0
+
+- Set workspace specific snippets and allows snippets to sync via git with your `.vscode` folder.
 ## 1.1.1
 
 - Make default snippets path available after fresh installation.
@@ -115,7 +124,7 @@ alt="Permissions issue">
 - Enable/disable snippets syntax resolving.
 - Change default snippets location using settings property `snippets.snippetsLocation`.
 
-### 1.0.0
+## 1.0.0
 
 Initial release of the extension.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "snippets",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "SEE LICENSE IN LICENSE.txt",
 			"dependencies": {
 				"@types/mustache": "^4.0.1",
@@ -700,22 +700,26 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.14.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-			"integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+			"version": "4.16.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
 			"dev": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001157",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.591",
+				"caniuse-lite": "^1.0.30001219",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.723",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.66"
+				"node-releases": "^1.1.71"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -743,10 +747,14 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001161",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-			"integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
-			"dev": true
+			"version": "1.0.30001230",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+			"integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/browserslist"
+			}
 		},
 		"node_modules/chalk": {
 			"version": "4.1.0",
@@ -893,9 +901,9 @@
 			"dev": true
 		},
 		"node_modules/colorette": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"node_modules/command-line-usage": {
@@ -1029,9 +1037,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.608",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.608.tgz",
-			"integrity": "sha512-dZsqCe7WgOcFse1QxIrm3eR+ebF13f0HfzM5QW9WtP1XVsQVrl/6R3DjexfVdupfwaS6znEDcP0NTBlJii7sOA==",
+			"version": "1.3.739",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+			"integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -2232,9 +2240,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.67",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+			"version": "1.1.72",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+			"integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
@@ -4134,16 +4142,16 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.14.7",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-			"integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+			"version": "4.16.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001157",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.591",
+				"caniuse-lite": "^1.0.30001219",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.723",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.66"
+				"node-releases": "^1.1.71"
 			}
 		},
 		"buffer-from": {
@@ -4165,9 +4173,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001161",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-			"integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
+			"version": "1.0.30001230",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+			"integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
 			"dev": true
 		},
 		"chalk": {
@@ -4290,9 +4298,9 @@
 			"dev": true
 		},
 		"colorette": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-			"integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 			"dev": true
 		},
 		"command-line-usage": {
@@ -4401,9 +4409,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.608",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.608.tgz",
-			"integrity": "sha512-dZsqCe7WgOcFse1QxIrm3eR+ebF13f0HfzM5QW9WtP1XVsQVrl/6R3DjexfVdupfwaS6znEDcP0NTBlJii7sOA==",
+			"version": "1.3.739",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+			"integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -5353,9 +5361,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.67",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+			"version": "1.1.72",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+			"integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
 			"dev": true
 		},
 		"normalize-path": {

--- a/package.json
+++ b/package.json
@@ -254,6 +254,11 @@
 		"configuration": {
 			"title": "Snippets",
 			"properties": {
+				"snippets.useWorkspaceFolder": {
+					"type": "boolean",
+					"default": false,
+					"description": "Use the workspace folder as root to save snippets instead of user settings. Can be specified with the snippet location setting"
+				},
 				"snippets.snippetsLocation": {
 					"type": [
 						"string",

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
 				"snippets.useWorkspaceFolder": {
 					"type": "boolean",
 					"default": false,
-					"description": "Use the workspace folder as root to save snippets instead of user settings. Can be specified with the snippet location setting"
+					"description": "Use the workspace .vscode folder to save snippets as a snippets.json file (overrides the snippetsLocation)"
 				},
 				"snippets.snippetsLocation": {
 					"type": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "snippets",
 	"displayName": "Snippets",
 	"description": "Manage your code snippets without quitting your editor.",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"preview": true,
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"publisher": "tahabasri",

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -24,7 +24,9 @@ export const enum Labels {
 
 	snippetsDefaultPath = "Snippets will be saved to default location [{0}].",
 	snippetsWorkspacePath = "Snippets will be saved to workspace location [{0}].",
-	snippetsWorkspaceInvalidPath = "Snippets will be saved to workspace location [{0}].",
+	snippetsWorkspaceCreateFileOption = "Workspace snippets is enabled but no snippets file is found",
+	snippetsWorkspaceCreateFileOptionMakeJson = "Make new file",
+	snippetsWorkspaceCreateFileOptionUseGlobal = "Use global snippets",
 	snippetsInvalidPath = "Snippets path [{0}] is not a valid JSON file, will revert back to default location [{1}].",
 	snippetsChangedPath = "Snippets location changed to [{0}]",
 	snippetsInvalidNewPath = "Snippets path [{0}] is not a valid JSON file, will revert back to old location [{1}].",

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -1,10 +1,10 @@
 export const enum Labels {
-    noOpenEditor = "No open editor was found.",
+	noOpenEditor = "No open editor was found.",
 	noOpenTerminal = "No open terminal was found.",
 	noValueGiven = "No value was given.",
 	noTextSelected = "No text was selected from active editor.",
 	noClipboardContent = "No content was found in the clipboard.",
-	
+
 	insertSnippetName = "Select the snippet you want to open ...",
 
 	snippetValuePrompt = "Snippet Value",
@@ -23,6 +23,8 @@ export const enum Labels {
 	snippetFolderNameErrorMsg = "Snippet folder must have a non-empty name.",
 
 	snippetsDefaultPath = "Snippets will be saved to default location [{0}].",
+	snippetsWorkspacePath = "Snippets will be saved to workspace location [{0}].",
+	snippetsWorkspaceInvalidPath = "Snippets will be saved to workspace location [{0}].",
 	snippetsInvalidPath = "Snippets path [{0}] is not a valid JSON file, will revert back to default location [{1}].",
 	snippetsChangedPath = "Snippets location changed to [{0}]",
 	snippetsInvalidNewPath = "Snippets path [{0}] is not a valid JSON file, will revert back to old location [{1}].",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,24 +34,22 @@ export function activate(context: vscode.ExtensionContext) {
 
 	if (settings.useWorkspaceFolder && !fs.existsSync(snippetsPath)) {
 		vscode.window.showWarningMessage(Labels.snippetsWorkspaceCreateFileOption, Labels.snippetsWorkspaceCreateFileOptionMakeJson, Labels.snippetsWorkspaceCreateFileOptionUseGlobal).then(selection => {
-			if (selection == Labels.snippetsWorkspaceCreateFileOptionMakeJson) {
+			if (selection === Labels.snippetsWorkspaceCreateFileOptionMakeJson) {
 				new DataAccess(snippetsPath).setDataFile(snippetsPath);
 				vscode.window.showInformationMessage(
 					StringUtility.formatString(Labels.snippetsWorkspacePath, snippetsPath)
 				);
 			}
-			else if (selection == Labels.snippetsWorkspaceCreateFileOptionUseGlobal) {
-				snippetsPath = defaultSnippetsPath
+			else if (selection === Labels.snippetsWorkspaceCreateFileOptionUseGlobal) {
+				snippetsPath = defaultSnippetsPath;
 				vscode.window.showInformationMessage(
 					StringUtility.formatString(Labels.snippetsDefaultPath, snippetsPath)
 				);
 			}
-			activate_extension(context, snippetsPath, defaultSnippetsPath, snippetsPathConfigKey, explicitUpdate)
+			activateExtension(context, snippetsPath, defaultSnippetsPath, snippetsPathConfigKey, explicitUpdate);
 		});
 		return;
-	}
-
-	else {
+	} else {
 		// revert back to default snippets path if there is no entry in settings or there is one but it is not a valid JSON file
 		const revertToDefaultLocation = snippetsPath === "" || !fs.existsSync(snippetsPath) || !fs.statSync(snippetsPath).isFile || !snippetsPath.endsWith(DataAccess.dataFileExt);
 		if (revertToDefaultLocation) {
@@ -73,11 +71,12 @@ export function activate(context: vscode.ExtensionContext) {
 			snippetsPath = defaultSnippetsPath;
 		}
 	}
-	activate_extension(context, snippetsPath, defaultSnippetsPath, snippetsPathConfigKey, explicitUpdate)
+
+	activateExtension(context, snippetsPath, defaultSnippetsPath, snippetsPathConfigKey, explicitUpdate);
 }
 
 //changed continue function, needed to wait for user input if needed.
-export function activate_extension(context: vscode.ExtensionContext, snippetsPath: string, defaultSnippetsPath: string, snippetsPathConfigKey: string, explicitUpdate: boolean) {
+export function activateExtension(context: vscode.ExtensionContext, snippetsPath: string, defaultSnippetsPath: string, snippetsPathConfigKey: string, explicitUpdate: boolean) {
 	const dataAccess = new DataAccess(snippetsPath);
 	const snippetService = new SnippetService(dataAccess);
 	const snippetsProvider = new SnippetsProvider(snippetService, context.extensionPath);


### PR DESCRIPTION
This allows snippets to be mapped to a file in the workspace
and allows the use of snippets per work item if you work with multiple workspaces and have it sync together with your project files. like requested in issue #19 