### PR TITLE
Add feature for import/export Snippets.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "snippets",
 	"displayName": "Snippets",
 	"description": "Manage your code snippets without quitting your editor.",
-	"version": "2.1.0",
-	"preview": false,
+	"version": "2.2.0",
+	"preview": true,
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"publisher": "tahabasri",
 	"author": {
@@ -43,7 +43,7 @@
 		"viewsWelcome": [
 			{
 				"view": "snippetsExplorer",
-				"contents": "In order to use snippets, save some code here.\n[Add Snippet](command:globalSnippetsCmd.addSnippet)\n[Add Snippet Folder](command:globalSnippetsCmd.addSnippetFolder)\nTo learn more about how to use snippets [read the docs](https://github.com/tahabasri/snippets/blob/main/README.md)."
+				"contents": "In order to use snippets, save some code here.\n[Add Snippet](command:globalSnippetsCmd.addSnippet)\n[Add Snippet Folder](command:globalSnippetsCmd.addSnippetFolder)\n[Import Snippets](command:globalSnippetsCmd.importSnippets)\nTo learn more about how to use snippets [read the docs](https://github.com/tahabasri/snippets/blob/main/README.md)."
 			},
 			{
 				"view": "wsSnippetsExplorer",
@@ -200,6 +200,18 @@
 				"title": "Move Snippet Down",
 				"icon": "$(marker-navigation-next)",
 				"category": "Snippets"
+			},
+			{
+				"command": "globalSnippetsCmd.exportSnippets",
+				"title": "Export Snippets",
+				"icon": "$(cloud-upload)",
+				"category": "Snippets"
+			},
+			{
+				"command": "globalSnippetsCmd.importSnippets",
+				"title": "Import Snippets",
+				"icon": "$(cloud-download)",
+				"category": "Snippets"
 			}
 		],
 		"menus": {
@@ -314,7 +326,17 @@
 				{
 					"command": "globalSnippetsCmd.addSnippetFromClipboard",
 					"when": "view == snippetsExplorer",
-					"group": "other"
+					"group": "other@1"
+				},
+				{
+					"command": "globalSnippetsCmd.exportSnippets",
+					"when": "view == snippetsExplorer",
+					"group": "other@2"
+				},
+				{
+					"command": "globalSnippetsCmd.importSnippets",
+					"when": "view == snippetsExplorer",
+					"group": "other@3"
 				},
 				{
 					"command": "wsSnippetsCmd.addSnippetFromClipboard",

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -49,4 +49,12 @@ export const enum Labels {
 	snippetsWorkspaceFileCreated = "File was successfully created in [{0}]",
 
 	genericError = "[{0}]. You may refresh current window to fix issue.",
+
+	snippetExportDestinationErrorMsg = "Export destination must not be empty.",
+
+	importSnippets = "Import data",
+	discardImport = "Discard import",
+	snippetImportRequestConfirmation = "All your global snippets will be replaced with the imported ones (except for workspace snippets)! Do you want to proceed ? (A backup file of your snippets will be saved in case of a rollback).",
+	snippetsImported = "Snippets imported. Kept a backup of old snippets next to the imported file in case of a rollback.",
+	snippetsNotImported = "Snippets weren't imported. Please check the file content or redo a proper export/import (A copy of your old snippets was saved next to the recently imported file)",
 }

--- a/src/data/fileDataAccess.ts
+++ b/src/data/fileDataAccess.ts
@@ -33,7 +33,7 @@ export class FileDataAccess implements DataAccess {
         }
         let rawData = fs.readFileSync(this._dataFile, this._encoding);
         
-        if (this.isBlank(rawData)) {
+        if (this.isBlank(rawData)) {
             this.save(DataAccessConsts.defaultRootElement);
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -433,6 +433,16 @@ export function activate(context: vscode.ExtensionContext) {
     //** COMMAND : REFRESH **/
 
     context.subscriptions.push(vscode.commands.registerCommand("commonSnippetsCmd.refreshEntry", _ => refreshUI()));
+
+    //** COMMAND : IMPORT & EXPORT **/
+
+    context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalExportSnippets,
+        async _ => handleCommand(() => commands.exportSnippets(snippetsProvider))
+    ));
+    
+    context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalImportSnippets,
+        async _ => handleCommand(() => commands.importSnippets(snippetsProvider))
+    ));
 }
 
 export function deactivate() { }

--- a/src/provider/snippetsProvider.ts
+++ b/src/provider/snippetsProvider.ts
@@ -150,4 +150,16 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet> {
         }
         return treeItem;
     }
+
+    exportSnippets(destinationPath: string) {
+        this._snippetService.exportSnippets(destinationPath, Snippet.rootParentId);
+        this.sync();
+    }
+
+    importSnippets(destinationPath: string) : boolean {
+        this._snippetService.importSnippets(destinationPath);
+        this.sync();
+        const parentElt = this._snippetService.getParent(undefined);
+        return parentElt !== undefined && parentElt.children!== undefined && parentElt.children.length > 0;
+    }
 }

--- a/src/service/snippetService.ts
+++ b/src/service/snippetService.ts
@@ -1,4 +1,5 @@
 import { DataAccess } from "../data/dataAccess";
+import { FileDataAccess } from "../data/fileDataAccess";
 import { Snippet } from "../interface/snippet";
 
 export class SnippetService {
@@ -156,5 +157,24 @@ export class SnippetService {
                 this._reorderArray(parentElement.children, index, index + offset);
             }
         }
+    }
+
+    exportSnippets(destinationPath: string, parentId: number) {
+        const parentElement = SnippetService.findParent(parentId ?? Snippet.rootParentId, this._rootSnippet);
+        if (parentElement) {
+            // save file using destroyable instance of FileDataAccess
+            new FileDataAccess(destinationPath).save(parentElement);
+        }
+    }
+
+    importSnippets(destinationPath: string) {
+        // save a backup version of current snippets next to the file to import
+        this.exportSnippets(
+            destinationPath.replace(FileDataAccess.dataFileExt, `_pre-import-bak${FileDataAccess.dataFileExt}`),
+            Snippet.rootParentId
+        );
+        let newSnippets: Snippet = new FileDataAccess(destinationPath).load();
+        this._rootSnippet.children = newSnippets.children;
+        this._rootSnippet.lastId = newSnippets.lastId;
     }
 }


### PR DESCRIPTION
Fixes #36 

![image](https://user-images.githubusercontent.com/12661966/146968033-f521eeac-5c2e-4ace-9463-34f180a1d32f.png)

- Export Snippets to a user defined JSON file.
- Import Snippets from an already saved JSON file. The process of the import is the following :
  1. Save a backup file for current snippets next to the file to import. This will help in case of a rollback.
  2. Override all global snippets (except workspace related) with the data from the imported file.

The startup section/view was updated to include an option of directly importing snippets for fresh installations.

![image](https://user-images.githubusercontent.com/12661966/146968138-3a498cf9-52a6-4b36-a3e3-0322169dc7f9.png)
