### PR TITLE
Customize Suggestions Trigger Key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,7 +502,14 @@
 				"snippets.showSuggestions": {
 					"type": "boolean",
 					"default": true,
-					"description": "Show Snippets suggestions when typing `>` or when using your IntelliSense default trigger."
+					"markdownDescription": "Show Snippets suggestions when typing `#snippets.triggerKey#`."
+				},
+				"snippets.triggerKey": {
+					"type": "string",
+					"default": ">",
+					"minLength": 0,
+					"maxLength": 1,
+					"markdownDescription": "Character to be typed in order to show Snippets suggestions. `Note: Changes require a window restart to apply`."
 				},
 				"snippets.snippetsLocation": {
 					"deprecationMessage": "This is deprecated, the new default storage is VSCode globalState. This enables to sync snippets accross multiple machines. To keep using the file system as storage unit, consider using `#snippets.useWorkspaceFolder#`.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,7 +233,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     //** COMMAND : INITIALIZE GENERIC COMPLETION ITEM PROVIDER **/*
 
-    let triggerCharacter = ">";
+    let triggerCharacter : any = vscode.workspace.getConfiguration(snippetsConfigKey).get("triggerKey");
+    if (!triggerCharacter) {
+        triggerCharacter = "snp"; // placeholder which is not a simple character in order to trigger IntelliSense
+    }
     const registerCIPSnippets = () => cipDisposable = vscode.languages.registerCompletionItemProvider(
         '*', {
             provideCompletionItems(document, position) {


### PR DESCRIPTION
Fixes #39 

Added more flexibility to settings related to the suggestions feature :
![image](https://user-images.githubusercontent.com/12661966/168920200-1f008137-530e-4b21-9905-d4c4bbdeef04.png)

Additional option `Snippets: Trigger Key` was added to change to trigger character for suggestion. This can be helpful in a situation when you don't need a special character, but you care about having your snippets in IntelliSense. In that case, you can keep the option to show suggestions enabled and remove the trigger character from the settings (keep blank value).

`Note: Changes to the Trigger Key will require you to restart the current VS Code window`.