### PR TITLE
Confirm before removing snippet/folder + update settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -520,6 +520,11 @@
 					"default": null,
 					"format": "uri",
 					"description": "Specifies the folder path where to save snippets."
+				},
+				"snippets.confirmBeforeDeletion": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Show a confirmation alert before deleting a snippet/folder."
 				}
 			}
 		}

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -57,4 +57,7 @@ export const enum Labels {
 	snippetImportRequestConfirmation = "All your global snippets will be replaced with the imported ones (except for workspace snippets)! Do you want to proceed ? (A backup file of your snippets will be saved in case of a rollback).",
 	snippetsImported = "Snippets imported. Kept a backup of old snippets next to the imported file in case of a rollback.",
 	snippetsNotImported = "Snippets weren't imported. Please check the file content or redo a proper export/import (A copy of your old snippets was saved next to the recently imported file)",
+
+	confirmationYes = "Yes",
+	confirmationNo = "No",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,41 +233,41 @@ export function activate(context: vscode.ExtensionContext) {
 
     //** COMMAND : INITIALIZE GENERIC COMPLETION ITEM PROVIDER **/*
 
-    let triggerCharacter : any = vscode.workspace.getConfiguration(snippetsConfigKey).get("triggerKey");
+    let triggerCharacter: any = vscode.workspace.getConfiguration(snippetsConfigKey).get("triggerKey");
     if (!triggerCharacter) {
         triggerCharacter = "snp"; // placeholder which is not a simple character in order to trigger IntelliSense
     }
     const registerCIPSnippets = () => cipDisposable = vscode.languages.registerCompletionItemProvider(
         '*', {
-            provideCompletionItems(document, position) {
-                if (!vscode.workspace.getConfiguration(snippetsConfigKey).get("showSuggestions")) {
-                    return;
-                }
-                let isTriggeredByChar = triggerCharacter === document.lineAt(position).text.charAt(position.character - 1);
-                // append workspace snippets if WS is available
-                let candidates = snippetService.getAllSnippets();
-                if (workspaceSnippetsAvailable) {
-                    // add suffix for all workspace items
-                    candidates = candidates.concat(wsSnippetService.getAllSnippets().map(
-                        elt => {
-                            elt.label = `${elt.label}__(ws)`;
-                            return elt;
-                        }
-                    ));
-                }
-                return candidates.map(element =>
-                    <vscode.CompletionItem>{
-                        label: `snp:${element.label.replace('\n', '').replace(' ', '-').replace("__(ws)", " (ws)")}`,
-                        insertText: new vscode.SnippetString(element.value),
-                        detail: element.label.replace("__(ws)", " (snippet from workspace)"),
-                        kind: vscode.CompletionItemKind.Snippet,
-                        // replace trigger character with the chosen suggestion
-                        additionalTextEdits: isTriggeredByChar
-                            ? [vscode.TextEdit.delete(new vscode.Range(position.with(position.line, position.character - 1), position))]
-                            : []
-                    });
-            },
-        }, triggerCharacter
+        provideCompletionItems(document, position) {
+            if (!vscode.workspace.getConfiguration(snippetsConfigKey).get("showSuggestions")) {
+                return;
+            }
+            let isTriggeredByChar = triggerCharacter === document.lineAt(position).text.charAt(position.character - 1);
+            // append workspace snippets if WS is available
+            let candidates = snippetService.getAllSnippets();
+            if (workspaceSnippetsAvailable) {
+                // add suffix for all workspace items
+                candidates = candidates.concat(wsSnippetService.getAllSnippets().map(
+                    elt => {
+                        elt.label = `${elt.label}__(ws)`;
+                        return elt;
+                    }
+                ));
+            }
+            return candidates.map(element =>
+                <vscode.CompletionItem>{
+                    label: `snp:${element.label.replace('\n', '').replace(' ', '-').replace("__(ws)", " (ws)")}`,
+                    insertText: new vscode.SnippetString(element.value),
+                    detail: element.label.replace("__(ws)", " (snippet from workspace)"),
+                    kind: vscode.CompletionItemKind.Snippet,
+                    // replace trigger character with the chosen suggestion
+                    additionalTextEdits: isTriggeredByChar
+                        ? [vscode.TextEdit.delete(new vscode.Range(position.with(position.line, position.character - 1), position))]
+                        : []
+                });
+        },
+    }, triggerCharacter
     );
 
     context.subscriptions.push(registerCIPSnippets());
@@ -396,21 +396,69 @@ export function activate(context: vscode.ExtensionContext) {
     //** COMMAND : REMOVE SNIPPET **/
 
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalDeleteSnippet,
-        (snippet) => handleCommand(() => snippetsProvider.removeSnippet(snippet))
+        (snippet) => handleCommand(() => {
+            if (vscode.workspace.getConfiguration('snippets').get('confirmBeforeDeletion')) {
+                vscode.window
+                    .showInformationMessage(`Do you really want to delete the snippet (${snippet.label}) ?`, Labels.confirmationYes, Labels.confirmationNo)
+                    .then(answer => {
+                        if (answer === Labels.confirmationYes) {
+                            snippetsProvider.removeSnippet(snippet);
+                        }
+                    });
+            } else {
+                snippetsProvider.removeSnippet(snippet);
+            }
+        })
     ));
 
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.wsDeleteSnippet,
-        (snippet) => handleCommand(() => wsSnippetsProvider.removeSnippet(snippet))
+        (snippet) => handleCommand(() => {
+            if (vscode.workspace.getConfiguration('snippets').get('confirmBeforeDeletion')) {
+                vscode.window
+                    .showInformationMessage(`Do you really want to delete the snippet (${snippet.label}) ?`, Labels.confirmationYes, Labels.confirmationNo)
+                    .then(answer => {
+                        if (answer === Labels.confirmationYes) {
+                            wsSnippetsProvider.removeSnippet(snippet);
+                        }
+                    });
+            } else {
+                wsSnippetsProvider.removeSnippet(snippet);
+            }
+        })
     ));
 
     //** COMMAND : REMOVE SNIPPET FOLDER **/
 
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalDeleteSnippetFolder,
-        (snippetFolder) => handleCommand(() => snippetsProvider.removeSnippet(snippetFolder))
+        (snippetFolder) => handleCommand(() => {
+            if (vscode.workspace.getConfiguration('snippets').get('confirmBeforeDeletion')) {
+                vscode.window
+                    .showInformationMessage(`Do you really want to delete the folder (${snippetFolder.label}) ?`, Labels.confirmationYes, Labels.confirmationNo)
+                    .then(answer => {
+                        if (answer === Labels.confirmationYes) {
+                            snippetsProvider.removeSnippet(snippetFolder);
+                        }
+                    });
+            } else {
+                snippetsProvider.removeSnippet(snippetFolder);
+            }
+        })
     ));
 
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.wsDeleteSnippetFolder,
-        (snippetFolder) => handleCommand(() => wsSnippetsProvider.removeSnippet(snippetFolder))
+        (snippetFolder) => handleCommand(() => {
+            if (vscode.workspace.getConfiguration('snippets').get('confirmBeforeDeletion')) {
+                vscode.window
+                    .showInformationMessage(`Do you really want to delete the folder (${snippetFolder.label}) ?`, Labels.confirmationYes, Labels.confirmationNo)
+                    .then(answer => {
+                        if (answer === Labels.confirmationYes) {
+                            wsSnippetsProvider.removeSnippet(snippetFolder);
+                        }
+                    });
+            } else {
+                wsSnippetsProvider.removeSnippet(snippetFolder);
+            }
+        })
     ));
 
     //** COMMAND : MOVE SNIPPET UP **/
@@ -442,7 +490,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalExportSnippets,
         async _ => handleCommand(() => commands.exportSnippets(snippetsProvider))
     ));
-    
+
     context.subscriptions.push(vscode.commands.registerCommand(commands.CommandsConsts.globalImportSnippets,
         async _ => handleCommand(() => commands.importSnippets(snippetsProvider))
     ));


### PR DESCRIPTION
Fixes #41 
- Show confirmation alert before deleting snippet/folder
![image](https://user-images.githubusercontent.com/12661966/168924519-4d275f85-974d-4bde-9145-f8ceef5b7ad1.png)

- Add configuration to enable/disable confirmation before deletion
![image](https://user-images.githubusercontent.com/12661966/168924472-c3522306-7b64-4817-b662-e1ef7457d454.png)
