### PR TITLE
Add tab support when editing Snippets

### DIFF
--- a/views/editSnippet.html
+++ b/views/editSnippet.html
@@ -26,7 +26,7 @@
                 <label for="snippet-resolveSyntax"> Resolve Snippet Syntax</label>
             </div>
         </div>
-        <div><textarea name="snippet-value" rows="10" required>{{snippet.value}}</textarea></div>
+        <div><textarea id="snippet-value" name="snippet-value" rows="10" required>{{snippet.value}}</textarea></div>
         <div><input type="submit" value="Save"></div>
     </form>
 </body>

--- a/views/js/editSnippet.js
+++ b/views/js/editSnippet.js
@@ -1,4 +1,18 @@
 (function() {
+    // add TAB support
+    const snippetValue = document.getElementById('snippet-value');
+    snippetValue.addEventListener('keydown', keyHandler, false);
+    function keyHandler(e) {
+        var TABKEY = 9;
+        if(e.keyCode === TABKEY) {
+            this.value += "\t";
+            if(e.preventDefault) {
+                e.preventDefault();
+            }
+            return false;
+        }
+    }
+
     const vscode = acquireVsCodeApi();
 
     const resolveSyntaxCB = document.lastChild.querySelector('input[name="_snippets_resolve_syntax"]');


### PR DESCRIPTION
When editing a snippet, tab key will add space instead of setting focus outside the editor.