### PR TITLE
Expand tooltip content

### DIFF
--- a/src/provider/snippetsProvider.ts
+++ b/src/provider/snippetsProvider.ts
@@ -179,11 +179,7 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet>, vscod
                 dark: path.join(this._extensionPath, 'resources', 'icons', 'dark', 'folder.svg')
             };
         } else {
-            const maxLength = 20;
-            treeItem.tooltip = `${snippet.value
-                ? "'" + snippet.value.replace('\n', '').slice(0, maxLength)
-                + (snippet.value.length > 20 ? '...' : '') + "'"
-                : "''"}`;
+            treeItem.tooltip = `${snippet.value}`;
             treeItem.contextValue = 'snippet';
             treeItem.iconPath = {
                 light: path.join(this._extensionPath, 'resources', 'icons', 'light', 'file.svg'),


### PR DESCRIPTION
Tooltip content is expanded to multiple lines:
![image](https://github.com/tahabasri/snippets/assets/12661966/970cbd28-1637-464b-befa-1ab004af83e0)
