### PR TITLE
[#123] Surface language-less Snippets as Global in IntelliSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ You can explicitly set a programming language by appending the language file ext
 <img src="https://raw.githubusercontent.com/tahabasri/snippets/main/images/features/038-language-scope-by-name.gif" 
 alt="Manually Bind Snippets to Languages">
 
+#### Global Snippets
+
+Snippets saved without a language scope are **global**: they appear in IntelliSense in every file, regardless of the active language. Pick `Global (all languages)` from the language picker on a Snippet to make it available everywhere.
+
+> Plain Text files always show every Snippet, global or language-scoped, since they are the default language for new untitled files.
+
 ### Resolve Snippet Syntax
 
 > Learn more about the Snippet syntax [here](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -332,6 +332,18 @@ export function activate(context: vscode.ExtensionContext) {
     const registerCIPSnippetsList: (() => vscode.Disposable)[] = [];
 
     for (const currentLanguage of allLanguages) {
+        // plaintext is served by the '**' provider below, which shows every snippet
+        // regardless of language scope. Skipping the regular plaintext iteration here
+        // avoids registering two providers against the same language.
+        if (currentLanguage.id === 'plaintext') {
+            continue;
+        }
+        // '**' is the dedicated plaintext provider: it surfaces every snippet so users
+        // get full IntelliSense in untitled files (which default to plaintext).
+        // For real languages, snippets with no language are treated as global and shown
+        // alongside language-scoped ones.
+        const isGlobalProvider = currentLanguage.id === '**';
+        const matches = (s: Snippet) => isGlobalProvider || !s.language || s.language === currentLanguage.extension;
         let disposable =  currentLanguage.id === '**' ? globalCipDisposable : cipDisposable;
         const registerCIPSnippets = () => disposable = vscode.languages.registerCompletionItemProvider(
             currentLanguage.id === '**' // use pattern filter for non-language snippets
@@ -344,17 +356,13 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                     LoggingUtility.getInstance().debug('Registering completion items for language : ' + currentLanguage.id);
                     let isTriggeredByChar: boolean = triggerCharacter === document.lineAt(position).text.charAt(position.character - 1);
-                    let candidates = snippetService.getAllSnippets()
-                        .filter(s => (currentLanguage.id === '**' && (s.language === currentLanguage.extension || !s.language)) 
-                                        || s.language === currentLanguage.extension);
+                    let candidates = snippetService.getAllSnippets().filter(matches);
                     // append workspace snippets if WS is available
                     if (workspaceSnippetsAvailable) {
                         // add suffix for all workspace items
                         candidates = candidates.concat(
                             wsSnippetService.getAllSnippets()
-                                .filter(s => (currentLanguage.id === '**' 
-                                    && (s.language === currentLanguage.extension || !s.language)) 
-                                    || s.language === currentLanguage.extension)
+                                .filter(matches)
                                 .map(elt => {
                                     elt.completionDescription = `${elt.description ? elt.description + ' ' : ''}__(ws)`;
                                     return elt;

--- a/views/editSnippet.html
+++ b/views/editSnippet.html
@@ -34,14 +34,14 @@
                 <div class="no-m">
                     <label for="snippet-language">Snippet Language Scope
                         <div class="tooltip"> [?]
-                            <span class="tooltiptext">Snippet will be suggested for files of the selected language only.
+                            <span class="tooltiptext">Pick a language to scope the snippet, or Global to show it in every file. Plain Text always shows all snippets.
                             </span>
                         </div>
                     </label>
                 </div>
                 <div>
                     <select id="snippet-language" name="snippet-language" init-value="{{ snippet.language }}">
-                        <option value="">--none--</option>
+                        <option value="">Global (all languages)</option>
                         {{#languages}}
                             <li>{{name}}</li>
                             <option value="{{extension}}">{{alias}}</option>


### PR DESCRIPTION
## Summary
- Fixes #123. Snippets saved without a language are now treated as **Global** and surface in IntelliSense across every language.
- The `**` completion provider keeps its role for Plain Text and now offers every snippet (global *and* language-scoped), so untitled files get full IntelliSense.
- Edit dialog: renames the no-language option to `Global (all languages)` and updates the tooltip.
- README: new "Global Snippets" subsection under *Bind Snippets to Programming Languages*.

## Behavior matrix
| Snippet scope | Plain Text | Snippet language | Other languages |
|---|---|---|---|
| Global (no language) | ✅ | ✅ | ✅ |
| Language-specific (e.g. TS) | ✅ | ✅ | ❌ |

## Test plan
- [ ] Create a Snippet with `Global (all languages)`; confirm it appears in IntelliSense in `.ts`, `.py`, `.md`, and untitled Plain Text files
- [ ] Create a Snippet scoped to TypeScript; confirm it only appears in `.ts` files and in Plain Text
- [ ] Confirm existing language-scoped Snippets still behave the same in their own language
- [ ] Edit an existing Snippet and verify the language picker shows `Global (all languages)` and the updated tooltip