### PR TITLE
[#124] Add setting to open folders collapsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -834,6 +834,11 @@
 					"type": "boolean",
 					"default": false,
 					"markdownDescription": "Click the action buttons to open snippet in editor/terminal. This will disable openning snippet by clicking on the snippet name."
+				},
+				"snippets.collapseFolders": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Open folders collapsed. Expanding a folder then reveals only its immediate children, one level at a time, instead of expanding the whole subtree. This change requires a window restart."
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
     // workspace config
     const useWorkspaceFolderKey = "useWorkspaceFolder";
     const openButtonKey = "openButton";
+    const collapseFoldersKey = "collapseFolders";
     const workspaceFileName = ".vscode/snippets.json";
     let workspaceSnippetsAvailable = false;
     let wsSnippetService: SnippetService;
@@ -180,6 +181,9 @@ export function activate(context: vscode.ExtensionContext) {
         }
         if (event.affectsConfiguration(`${snippetsConfigKey}.${openButtonKey}`)) {
             handleButtonsVisibility();
+            refreshUI();
+        }
+        if (event.affectsConfiguration(`${snippetsConfigKey}.${collapseFoldersKey}`)) {
             refreshUI();
         }
     });

--- a/src/provider/snippetsProvider.ts
+++ b/src/provider/snippetsProvider.ts
@@ -179,10 +179,15 @@ export class SnippetsProvider implements vscode.TreeDataProvider<Snippet>, vscod
     }
 
     private snippetToTreeItem(snippet: Snippet): vscode.TreeItem {
+        // when 'collapseFolders' is enabled, folders open collapsed so that
+        // expanding one only reveals its immediate children (one level at a time)
+        const folderCollapsibleState = vscode.workspace.getConfiguration('snippets').get('collapseFolders')
+            ? vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.Expanded;
         let treeItem = new vscode.TreeItem(
             snippet.label + (snippet.language ? snippet.language : ''),
             snippet.folder && snippet.folder === true
-                ? vscode.TreeItemCollapsibleState.Expanded
+                ? folderCollapsibleState
                 : vscode.TreeItemCollapsibleState.None
         );
         // dynamic context value depending on item type (snippet or snippet folder)


### PR DESCRIPTION
Fixes #124 

    New `snippets.collapseFolders` setting (default off) renders folders in
    the Collapsed state so expanding one reveals only its immediate children,
    one level at a time, instead of cascading the whole subtree open.