### PR TITLE
[#129] Fix snippets randomly not saving + redesign editor layout

### DIFF
--- a/src/service/snippetService.ts
+++ b/src/service/snippetService.ts
@@ -172,19 +172,25 @@ export class SnippetService {
         const parentElement = SnippetService.findParent(snippet.parentId ?? Snippet.rootParentId, this._rootSnippet);
 
         if (parentElement) {
-            const index = parentElement.children.findIndex((obj => obj.id === snippet.id));
+            // Look the node up by id in the *current* in-memory tree and mutate it in place.
+            // Relying on the caller mutating a shared reference is unsafe: the tree is reloaded
+            // (getAllSnippets/refresh -> loadSnippets) on every IntelliSense lookup, which can
+            // leave an open edit webview holding a stale, orphaned node and silently drop the save.
+            const target = parentElement.children.find(obj => obj.id === snippet.id);
 
-            if (index > -1) {
-                parentElement.children.map(obj =>
-                    obj.id === snippet.id ? {
-                        ...obj,
-                        label: snippet.label,
-                        // if its a folder, don't update content, use old value instead
-                        // if its a snippet, update its content
-                        value: [snippet.folder ? obj.value : snippet.value]
-                    }
-                        : obj
-                );
+            if (target) {
+                target.label = snippet.label;
+                if (snippet.folder) {
+                    // folders: update icon, keep existing content untouched
+                    target.icon = snippet.icon;
+                } else {
+                    // snippets: update content and snippet-specific metadata
+                    target.value = snippet.value;
+                    target.language = snippet.language;
+                    target.description = snippet.description;
+                    target.prefix = snippet.prefix;
+                    target.resolveSyntax = snippet.resolveSyntax;
+                }
             }
         }
     }

--- a/src/test/suite/snippetService.test.ts
+++ b/src/test/suite/snippetService.test.ts
@@ -26,6 +26,29 @@ suite('SnippetService Tests', () => {
     }
   }
 
+  // DataAccess that hands back a fresh deep clone on every load, like FileDataAccess
+  // (JSON.parse) or a memento that re-deserializes. Used to reproduce the stale-reference
+  // bug where an open edit webview holds an orphaned node after the tree is reloaded.
+  class CloningMockDataAccess implements DataAccess {
+    private _data: Snippet = {
+      id: 1,
+      label: 'Root',
+      children: [],
+    };
+
+    hasNoChild(): boolean {
+      return !this._data.children || this._data.children.length === 0;
+    }
+
+    load(): Snippet {
+      return JSON.parse(JSON.stringify(this._data));
+    }
+
+    save(data: Snippet): void {
+      this._data = JSON.parse(JSON.stringify(data));
+    }
+  }
+
   // Mock the Memento object for testing
   class MockMemento implements Memento {
     keys(): readonly string[] {
@@ -66,6 +89,74 @@ suite('SnippetService Tests', () => {
     const allSnippets = snippetService.getAllSnippets();
     assert.strictEqual(allSnippets.length, 1);
     assert.strictEqual(allSnippets[0].label, 'New Snippet');
+  });
+
+  test('UpdateSnippet persists edited fields', () => {
+    // Arrange
+    const newSnippet: Snippet = {
+      id: 2,
+      parentId: 1,
+      label: 'Old Label',
+      value: 'old value',
+      children: [],
+    };
+    snippetService.addSnippet(newSnippet);
+
+    // Act
+    snippetService.updateSnippet({
+      id: 2,
+      parentId: 1,
+      label: 'New Label',
+      value: 'new value',
+      language: 'js',
+      description: 'desc',
+      prefix: 'pfx',
+      resolveSyntax: true,
+      children: [],
+    });
+
+    // Assert
+    const allSnippets = snippetService.getAllSnippets();
+    assert.strictEqual(allSnippets.length, 1);
+    assert.strictEqual(allSnippets[0].label, 'New Label');
+    assert.strictEqual(allSnippets[0].value, 'new value');
+    assert.strictEqual(allSnippets[0].language, 'js');
+    assert.strictEqual(allSnippets[0].description, 'desc');
+    assert.strictEqual(allSnippets[0].prefix, 'pfx');
+    assert.strictEqual(allSnippets[0].resolveSyntax, true);
+  });
+
+  test('UpdateSnippet saves even when the caller holds a stale, orphaned node (issue #129)', () => {
+    // Arrange: a service whose backing store re-deserializes the tree on each load,
+    // so reloading produces fresh object references (like the real file/memento stores).
+    const service = new SnippetService(new CloningMockDataAccess());
+    const snip: Snippet = {
+      id: 2,
+      parentId: 1,
+      label: 'Old Label',
+      value: 'old value',
+      children: [],
+    };
+    service.addSnippet(snip);
+    service.saveSnippets();
+
+    // Simulate an IntelliSense completion lookup reloading the tree while the edit
+    // webview is open. The service's in-memory tree is now a fresh clone, and `snip`
+    // (still held by the webview) is an orphaned reference into the old tree.
+    service.getAllSnippets();
+
+    // Act: the webview mutates its orphaned node and asks the service to persist it.
+    snip.label = 'New Label';
+    snip.value = 'new value';
+    service.updateSnippet(snip);
+    service.saveSnippets();
+
+    // Assert: a fresh reload must reflect the edit (it would be silently lost before the fix).
+    service.refresh();
+    const allSnippets = service.getAllSnippets();
+    assert.strictEqual(allSnippets.length, 1);
+    assert.strictEqual(allSnippets[0].label, 'New Label');
+    assert.strictEqual(allSnippets[0].value, 'new value');
   });
 
   test('RemoveSnippet removes a snippet correctly', () => {

--- a/views/css/vscode-custom.css
+++ b/views/css/vscode-custom.css
@@ -4,6 +4,7 @@
 	--input-padding-horizontal: 4px;
 	--input-margin-vertical: 4px;
 	--input-margin-horizontal: 0;
+	--radius: 4px;
 }
 
 body {
@@ -46,6 +47,7 @@ code {
 
 button {
 	border: none;
+	border-radius: var(--radius);
 	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
 	width: 100%;
 	text-align: center;
@@ -79,6 +81,7 @@ textarea {
 	width: 100%;
 	max-width: 100%;
 	border: none;
+	border-radius: var(--radius);
 	font-family: var(--vscode-font-family);
 	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
 	color: var(--vscode-input-foreground);
@@ -104,10 +107,64 @@ textarea {
 		Bitstream Vera Sans Mono, monospace;
 }
 
+/* Style the native language picker to match a VS Code dropdown. */
+.select-wrapper {
+	position: relative;
+}
+
+.select-wrapper::after {
+	/* custom chevron drawn in CSS (webview CSP blocks data-URI images) */
+	content: "";
+	position: absolute;
+	top: 50%;
+	right: 10px;
+	width: 0;
+	height: 0;
+	pointer-events: none;
+	transform: translateY(-50%);
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-top: 5px solid var(--vscode-dropdown-foreground, var(--vscode-foreground));
+}
+
+select {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+	padding: var(--input-padding-vertical) 28px var(--input-padding-vertical) var(--input-padding-horizontal);
+	border: 1px solid var(--vscode-dropdown-border, transparent);
+	border-radius: var(--radius);
+	font-family: var(--vscode-font-family);
+	font-size: var(--vscode-font-size);
+	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
+	background-color: var(--vscode-dropdown-background, var(--vscode-input-background));
+	cursor: pointer;
+	appearance: none;
+	-webkit-appearance: none;
+}
+
+select:hover {
+	background-color: var(--vscode-dropdown-background, var(--vscode-input-background));
+}
+
+select:focus {
+	outline-color: var(--vscode-focusBorder);
+}
+
+select option {
+	color: var(--vscode-dropdown-foreground, var(--vscode-foreground));
+	background-color: var(--vscode-dropdown-listBackground, var(--vscode-dropdown-background, var(--vscode-input-background)));
+}
+
+/* Snippet-syntax notice: quote-styled like .hint but green (VS Code success text).
+   Toggled to display:block by editSnippet.js when snippet syntax is detected. */
 .popup {
-	display: inline;
-	color: var(--vscode-button-secondaryForeground);
-	background: var(--vscode-button-secondaryBackground);
+	margin: 2px 0 0;
+	padding: 2px 0 2px 8px;
+	border-left: 2px solid var(--vscode-charts-green, #89d185);
+	color: var(--vscode-charts-green, #89d185);
+	font-size: 0.9em;
 }
 
 .changelog-header {
@@ -128,27 +185,34 @@ input.saveButton {
 	background-color: var(--vscode-button-background);
 }
 
-/* Tooltip */
-.tooltip {
+/* Two-panel edit layout: content on the left (60%), Save + advanced options
+   on the right (40%) so the Save button stays visible (see issue #129). */
+.edit-layout {
+	display: flex;
+	gap: var(--container-paddding);
+	align-items: flex-start;
 	margin: 0;
-	position: relative;
-	display: inline-block;
-	border-bottom: 1px dotted black;
 }
 
-.tooltip .tooltiptext {
-	margin-left: 3px;
-	visibility: hidden;
-	min-width: max-content;
-	background-color: black;
-	color: #fff;
-	text-align: center;
-	padding: 5px 5px;
-	border-radius: 6px;
-	position: absolute;
-	z-index: 1;
+.left-panel {
+	flex: 3;
+	min-width: 0;
+	margin: 0;
 }
 
-.tooltip:hover .tooltiptext {
-	visibility: visible;
+.right-panel {
+	flex: 2;
+	min-width: 0;
+	margin: 0;
+}
+
+/* Field hint: always-visible helper text under a label, quote-styled with a
+   muted accent bar (replaces the old hover tooltip). */
+.hint {
+	margin: 2px 0 0;
+	padding: 2px 0 2px 8px;
+	border-left: 2px solid var(--vscode-input-border, var(--vscode-button-background));
+	color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+	font-size: 0.9em;
+	opacity: 0.85;
 }

--- a/views/editSnippet.html
+++ b/views/editSnippet.html
@@ -13,62 +13,49 @@
 
 <body>
     <form name="edit-snippet-form" data-vscode-context='{"preventDefaultContextMenuItems": true }'>
-        <div class="no-m"><label for="snippet-label">Snippet Label</label></div>
-        <div><input type="text" id="snippet-label" value="{{snippet.label}}" required></div>
-        <div>
-            <label for="snippet-value">Snippet Content</label>
-            <div class="popup" name="_snippets_syntax">
-                Snippet syntax was detected: see
-                <a href="{{docsUrl}}" target="_blank">docs</a>
-                for more information.
-                
-                <input type="checkbox" id="snippet-resolveSyntax" name="_snippets_resolve_syntax" value="{{snippet.resolveSyntax}}">
-                <label for="snippet-resolveSyntax"> Resolve Snippet Syntax</label>
+        <div class="edit-layout">
+            <div class="left-panel">
+                <div class="no-m"><label for="snippet-label">Snippet Label</label></div>
+                <div><input type="text" id="snippet-label" value="{{snippet.label}}" required></div>
+                <div class="no-m"><label for="snippet-description">Snippet Description</label></div>
+                <p class="hint">Optional description of the snippet displayed by IntelliSense.</p>
+                <div><input type="text" id="snippet-description" value="{{snippet.description}}"></div>
+                <div>
+                    <label for="snippet-value">Snippet Content</label>
+                    <div class="popup" name="_snippets_syntax">
+                        Snippet syntax was detected: see
+                        <a href="{{docsUrl}}" target="_blank">docs</a>
+                        for more information.
+
+                        <input type="checkbox" id="snippet-resolveSyntax" name="_snippets_resolve_syntax" value="{{snippet.resolveSyntax}}">
+                        <label for="snippet-resolveSyntax"> Resolve Snippet Syntax</label>
+                    </div>
+                </div>
+                <div><textarea id="snippet-value" name="snippet-value" rows="25" required>{{snippet.value}}</textarea></div>
+            </div>
+            <div class="right-panel">
+                <div><input class="saveButton" type="submit" value="Save"></div>
+                <!-- expand advanced options if expert mode is on -->
+                <details {{#expertMode}}open{{/expertMode}}>
+                    <summary>Advanced options</summary>
+                    <div>
+                        <div class="no-m"><label for="snippet-language">Snippet Language Scope</label></div>
+                        <p class="hint">Pick a language to scope the snippet, or Global to show it in every file. Plain Text always shows all snippets.</p>
+                        <div class="select-wrapper">
+                            <select id="snippet-language" name="snippet-language" init-value="{{ snippet.language }}">
+                                <option value="">Global (all languages)</option>
+                                {{#languages}}
+                                    <option value="{{extension}}">{{alias}}</option>
+                                {{/languages}}
+                            </select>
+                        </div>
+                        <div class="no-m"><label for="snippet-prefix">Snippet Prefix</label></div>
+                        <p class="hint">Trigger word that displays the snippet in IntelliSense. If unset, Snippet name will be used.</p>
+                        <div><input type="text" id="snippet-prefix" value="{{snippet.prefix}}"></div>
+                    </div>
+                </details>
             </div>
         </div>
-        <div><textarea id="snippet-value" name="snippet-value" rows="25" required>{{snippet.value}}</textarea></div>
-        <!-- expand advanced options if expert mode is on -->
-        <details {{#expertMode}}open{{/expertMode}}> 
-            <summary>Advanced options</summary>
-            <div>
-                <div class="no-m">
-                    <label for="snippet-language">Snippet Language Scope
-                        <div class="tooltip"> [?]
-                            <span class="tooltiptext">Pick a language to scope the snippet, or Global to show it in every file. Plain Text always shows all snippets.
-                            </span>
-                        </div>
-                    </label>
-                </div>
-                <div>
-                    <select id="snippet-language" name="snippet-language" init-value="{{ snippet.language }}">
-                        <option value="">Global (all languages)</option>
-                        {{#languages}}
-                            <li>{{name}}</li>
-                            <option value="{{extension}}">{{alias}}</option>
-                        {{/languages}}
-                    </select>
-                </div>
-                <div class="no-m">
-                    <label for="snippet-description">Snippet Description
-                        <div class="tooltip"> [?]
-                            <span class="tooltiptext">Optional description of the snippet displayed by IntelliSense.</span>
-                        </div>
-                    </label>
-                </div>
-                <div><input type="text" id="snippet-description" value="{{snippet.description}}"></div>
-                <div class="no-m">
-                    <label for="snippet-prefix">Snippet Prefix
-                        <div class="tooltip"> [?]
-                            <span class="tooltiptext">Trigger word that displays the snippet in IntelliSense.
-                                If unset, Snippet name will be used.
-                            </span>
-                        </div>
-                    </label>
-                </div>
-                <div><input type="text" id="snippet-prefix" value="{{snippet.prefix}}"></div>
-            </div>
-        </details>
-        <div><input class="saveButton" type="submit" value="Save"></div>
     </form>
 </body>
 

--- a/views/js/editSnippet.js
+++ b/views/js/editSnippet.js
@@ -73,7 +73,7 @@
         const regex = '\\${?\\w+(:?\\S*)}?';
         let re = new RegExp(regex);
         var res = element.value.search(re);
-        div.style.display = res < 0 ? "none" : "inline";
+        div.style.display = res < 0 ? "none" : "block";
     };
 
     const div = document.lastChild.querySelector('div[name="_snippets_syntax"]');


### PR DESCRIPTION
Fixes #129.

## Part 1 — Snippet edits randomly not saving

`SnippetService.updateSnippet` built a new array with `.map()` and **discarded the result**, so it never mutated the tree. Saves only worked by accident: the edit webview also mutated `this._snippet` directly, which was *usually* the same object reference living in the in-memory tree.

When an IntelliSense completion lookup or a tree refresh reloaded the tree (`getAllSnippets`/`refresh` → `loadSnippets` deserializes a fresh object tree) while an edit window was open, that reference became a **stale orphan**. On Save:
1. the webview mutated the orphan (no effect on the live tree),
2. `updateSnippet` was a no-op,
3. `sync()` persisted the live tree — without the edit. **Silently lost.**

`retainContextWhenHidden: true` keeps edit windows alive a long time, which is why this hit intermittently and was hard to reproduce.

**Fix:** `updateSnippet` now looks the node up by `id` in the *current* in-memory tree and mutates it in place, so persistence no longer depends on a shared reference. Added tests, including one that reproduces the exact stale-reference data loss (fails on the old code, passes now).

## Part 2 — Save button visibility + editor redesign

The Save button sat at the end of a long form and scrolled out of view, making it easy to forget to save. The edit view is reworked into a two-panel layout:

- **Left (60%):** label, description, content.
- **Right (40%):** Save button (always visible), then advanced options.
- Hover `[?]` tooltips replaced with always-visible, quote-styled hint text (VS Code Settings style); this also removes the off-screen absolute tooltips that caused a permanent horizontal scrollbar.
- Language picker styled as a native VS Code dropdown (theme tokens + CSS chevron).
- Green quote-styled "snippet syntax detected" notice.
- Reusable `--radius` variable; rounded inputs/select/buttons.