### PR TITLE
[#95] Fix snippet IntelliSense missing in remote sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,9 +350,13 @@ export function activate(context: vscode.ExtensionContext) {
         const matches = (s: Snippet) => isGlobalProvider || !s.language || s.language === currentLanguage.extension;
         let disposable =  currentLanguage.id === '**' ? globalCipDisposable : cipDisposable;
         const registerCIPSnippets = () => disposable = vscode.languages.registerCompletionItemProvider(
+            // No `scheme` filter: the provider must match every host, not just local
+            // files. Pinning scheme:'file'/'untitled' hid completions in remote sessions
+            // (Remote-SSH/WSL use vscode-remote, web/Codespaces use vscode-vfs) whenever
+            // the extension ran on the UI side — see issue #95.
             currentLanguage.id === '**' // use pattern filter for non-language snippets
-            ? [{ language: 'plaintext', scheme: 'file' }, { language: 'plaintext', scheme: 'untitled' }]
-            : [{ language: currentLanguage.id, scheme: 'file' }, { language: currentLanguage.id, scheme: 'untitled' }]
+            ? [{ language: 'plaintext' }]
+            : [{ language: currentLanguage.id }]
             , {
                 provideCompletionItems(document, position) {
                     if (!vscode.workspace.getConfiguration(snippetsConfigKey).get("showSuggestions")) {

--- a/src/test/suite/completionScheme.test.ts
+++ b/src/test/suite/completionScheme.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+/**
+ * Verification test for issue #95 — snippet IntelliSense does not fire in
+ * Remote-SSH (and other remote) sessions.
+ *
+ * The completion provider in extension.ts registers DocumentFilters that pin
+ * `scheme: 'file'` / `scheme: 'untitled'`. Remote documents (Remote-SSH, WSL,
+ * Dev Containers) use the `vscode-remote` scheme, so VS Code never matches the
+ * provider against them and `provideCompletionItems` is never called.
+ *
+ * `vscode.languages.match(selector, document)` is the exact API VS Code uses
+ * internally to decide whether to invoke a provider, so it lets us prove the
+ * root cause without an actual remote session.
+ */
+suite('Completion provider DocumentFilter / scheme (issue #95)', () => {
+
+  // Mirrors the filter currently built in extension.ts for a real language.
+  const currentFilter: vscode.DocumentSelector = [
+    { language: 'javascript', scheme: 'file' },
+    { language: 'javascript', scheme: 'untitled' }
+  ];
+
+  // Proposed fix: do not restrict by scheme, so any host (file/untitled/
+  // vscode-remote/vscode-vfs/...) matches.
+  const proposedFilter: vscode.DocumentSelector = [
+    { language: 'javascript' }
+  ];
+
+  const fakeDoc = (scheme: string, languageId = 'javascript') => ({
+    uri: vscode.Uri.parse(`${scheme}://authority/some/file.js`),
+    languageId
+  } as vscode.TextDocument);
+
+  test('current filter matches a LOCAL (file) document', () => {
+    assert.ok(vscode.languages.match(currentFilter, fakeDoc('file')) > 0,
+      'expected the current filter to match local file documents');
+  });
+
+  test('current filter FAILS to match a REMOTE (vscode-remote) document — reproduces #95', () => {
+    assert.strictEqual(vscode.languages.match(currentFilter, fakeDoc('vscode-remote')), 0,
+      'current filter unexpectedly matched a remote document');
+  });
+
+  test('proposed scheme-less filter matches a REMOTE (vscode-remote) document', () => {
+    assert.ok(vscode.languages.match(proposedFilter, fakeDoc('vscode-remote')) > 0,
+      'expected the proposed filter to match remote documents');
+  });
+
+  test('proposed scheme-less filter still matches LOCAL and untitled documents', () => {
+    assert.ok(vscode.languages.match(proposedFilter, fakeDoc('file')) > 0, 'should match file');
+    assert.ok(vscode.languages.match(proposedFilter, fakeDoc('untitled')) > 0, 'should match untitled');
+  });
+});


### PR DESCRIPTION
Closes #95

## Problem

Snippet IntelliSense did not fire in Remote-SSH / WSL sessions, while working normally without remote.

In a remote session VS Code can run this extension on the **UI (local) side** while the files being edited live on the **remote side**. Remote documents are tagged with the `vscode-remote` scheme (not `file`). The completion provider's `DocumentFilter` pinned `scheme: 'file'` / `scheme: 'untitled'`, so it never matched remote documents and no suggestions were offered. The snippets tree kept working because the extension/data are local — only the completion provider was affected.

## Fix

Drop the `scheme` restriction from the completion provider's `DocumentFilter` so it matches the document **language** on any host:

- `file` / `untitled` — unchanged
- `vscode-remote` (Remote-SSH / WSL) — now fixed
- `vscode-vfs` (web / Codespaces) — fixed as a bonus

The change is additive — no configuration loses completions it had before.

## Verification

- Reproduced the exact failure by pinning the extension to the UI side in a WSL session (snippet tree present, provider never firing on remote files), and confirmed suggestions appear after the change.
- Added a regression test (`src/test/suite/completionScheme.test.ts`) using `vscode.languages.match` to assert the new filter matches `vscode-remote` documents while the old scheme-pinned filter scored 0.